### PR TITLE
Fix for building on Windows.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,3 @@ subprojects {
     sourceCompatibility = "1.6"
     targetCompatibility = "1.6"
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.9'
-}


### PR DESCRIPTION
I don't really know enough about Gradle to debug this (and dont currently have enough time), but when building on Windows, we get a complaint about multiple definitions of this task, so i've removed it. These complaints don't appear to trigger on macOs or Linux, and removing this task seems as though it does not affect the other platforms.

If you can debug this or know what the problem is feel free to fix it another way, if you need to me try to repro something, feel free to ping me.