### PR TITLE
Check for unity installation through TC Tools system

### DIFF
--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityDetectorBase.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityDetectorBase.kt
@@ -41,7 +41,7 @@ abstract class UnityDetectorBase : UnityDetector {
         // The convention to install multiple Unity versions is
         // to use suffixes for Unity directory, e.g. Unity_4.0b7
         directory.listFiles { file ->
-            file.isDirectory && (file.name.startsWith("Unity", true))
+            file.isDirectory && file.name.startsWith("Unity", true)
         }?.let { files ->
             yieldAll(files.asSequence())
         }

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityDetectorBase.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityDetectorBase.kt
@@ -3,6 +3,7 @@ package jetbrains.buildServer.unity
 import java.io.File
 
 abstract class UnityDetectorBase : UnityDetector {
+    private val additionalHintPaths: MutableCollection<File> = mutableListOf()
 
     protected open fun getHintPaths() = sequence {
         // Get paths from "UNITY_HOME" environment variables
@@ -13,13 +14,18 @@ abstract class UnityDetectorBase : UnityDetector {
                 })
             }
         }
+
+        // Get paths from "additional directories"
+        additionalHintPaths.forEach { hintPath ->
+            yieldAll(findUnityPaths(hintPath))
+        }
     }
 
     protected fun findUnityPaths(directory: File) = sequence {
         // The convention to install multiple Unity versions is
         // to use suffixes for Unity directory, e.g. Unity_4.0b7
         directory.listFiles { file ->
-            file.isDirectory && file.name.startsWith("Unity")
+            file.isDirectory && (file.name.toLowerCase().startsWith("unity"))
         }?.let { files ->
             yieldAll(files.asSequence())
         }
@@ -32,5 +38,10 @@ abstract class UnityDetectorBase : UnityDetector {
         }?.let { files ->
             yieldAll(files.asSequence())
         }
+    }
+
+    fun registerAdditionalHintPath(hintPath: File)
+    {
+        additionalHintPaths.add(hintPath)
     }
 }

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
@@ -34,8 +34,13 @@ class UnityToolProvider(toolsRegistry: ToolProvidersRegistry,
         events.addListener(this)
     }
 
-    override fun beforeAgentConfigurationLoaded(agent: BuildAgent) {
+    override fun afterAgentConfigurationLoaded(agent: BuildAgent) {
+        super.afterAgentConfigurationLoaded(agent)
+
         LOG.info("Locating ${UnityConstants.RUNNER_DISPLAY_NAME} tools")
+
+        unityDetector?.registerAdditionalHintPath(agent.configuration.agentToolsDirectory)
+
         unityDetector?.findInstallations()?.let { versions ->
             unityVersions.putAll(versions.sortedBy { it.first }.map {
                 it.first.toString() to it.second.absolutePath

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
@@ -35,16 +35,16 @@ class UnityToolProvider(toolsRegistry: ToolProvidersRegistry,
     }
 
     override fun afterAgentConfigurationLoaded(agent: BuildAgent) {
-        super.afterAgentConfigurationLoaded(agent)
-
         LOG.info("Locating ${UnityConstants.RUNNER_DISPLAY_NAME} tools")
 
-        unityDetector?.registerAdditionalHintPath(agent.configuration.agentToolsDirectory)
-
-        unityDetector?.findInstallations()?.let { versions ->
-            unityVersions.putAll(versions.sortedBy { it.first }.map {
-                it.first.toString() to it.second.absolutePath
-            }.toMap())
+        unityDetector?.let { detector ->
+            detector.registerAdditionalHintPath(agent.configuration.agentToolsDirectory)
+            
+            detector.findInstallations().let { versions ->
+                unityVersions.putAll(versions.sortedBy { it.first }.map {
+                    it.first.toString() to it.second.absolutePath
+                }.toMap())
+            }
         }
 
         // Report all Unity versions

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/WindowsUnityDetector.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/WindowsUnityDetector.kt
@@ -1,7 +1,7 @@
 package jetbrains.buildServer.unity
 
 import com.github.zafarkhaja.semver.Version
-import jetbrains.buildServer.agent.runner.JavaCommandLineBuilder.LOG
+import com.intellij.openapi.diagnostic.Logger
 import jetbrains.buildServer.util.PEReader.PEUtil
 import java.io.File
 
@@ -32,5 +32,9 @@ class WindowsUnityDetector : UnityDetectorBase() {
             if (path.isEmpty()) return@forEach
             yieldAll(findUnityPaths(File(path)))
         }
+    }
+    
+    companion object {
+        private val LOG = Logger.getInstance(WindowsUnityDetector::class.java.name)
     }
 }

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/WindowsUnityDetector.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/WindowsUnityDetector.kt
@@ -15,7 +15,8 @@ class WindowsUnityDetector : UnityDetectorBase() {
 
     override fun findInstallations() = sequence {
         getHintPaths().distinct().forEach {  path ->
-            LOG.info("Checking $path")
+            LOG.debug("Looking for Unity installation in $path")
+
             val executable = getEditorPath(path)
             if (!executable.exists()) return@forEach
 

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/WindowsUnityDetector.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/WindowsUnityDetector.kt
@@ -1,12 +1,14 @@
 package jetbrains.buildServer.unity
 
 import com.github.zafarkhaja.semver.Version
+import jetbrains.buildServer.agent.runner.JavaCommandLineBuilder.LOG
 import jetbrains.buildServer.util.PEReader.PEUtil
 import java.io.File
 
 class WindowsUnityDetector : UnityDetectorBase() {
     override fun findInstallations() = sequence {
         getHintPaths().distinct().forEach {  path ->
+            LOG.info("Checking $path")
             val executable = getEditorPath(path)
             if (!executable.exists()) return@forEach
 


### PR DESCRIPTION
We use the deprecated TeamCity Plugin developed by Mind Candy with some slight modifications : https://github.com/ArtOfSettling/Teamcity-unity3d-build-runner-plugin

One of which is that we distribute Unity installation through TeamCity's tools system, as zip packages. With this change, your detection system also monitors additional paths, in this case, TeamCity's tools folder.

For this change we've had to use afterAgentConfigurationLoaded as opposed to beforeAgentConfigurationLoaded. It's possible you've had internal discussions about this and that beforeAgentConfigurationLoaded is the correct place to perform your find unity steps, if that is the case and you can't accept this pull request, feel free to reject and consider this a feature request.

With this change, we've been able to get the teamcity-unity-plugin up and running with installs from the tools directory!

In order to conform with TeamCity tools standards, we also name our tools lower case unity, so I've made a slight change to the code to facilitate for this.

P.S. I think you haven't turned on the issue tracker on github for this plugin, or if you're wanting to refer users to the a YouTrack issue tracker, you might want to include a URL in the readme.