### PR TITLE
Fix a bug with the -projectPath argument.

### DIFF
--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -31,7 +31,7 @@ class UnityRunnerBuildService : BuildServiceAdapter() {
         var projectDir = workingDirectory
         runnerParameters[UnityConstants.PARAM_PROJECT_PATH]?.let {
             if (it.isNotEmpty()) {
-                projectDir = File(it.trim())
+                projectDir = File(workingDirectory, it.trim())
             }
         }
         arguments.addAll(listOf("-projectPath", projectDir.absolutePath))

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -31,7 +31,7 @@ class UnityRunnerBuildService : BuildServiceAdapter() {
         var workingDirectory = workingDirectory.absolutePath
         runnerParameters[UnityConstants.PARAM_PROJECT_PATH]?.let {
             if (it.isNotEmpty()) {
-                val projectFile = File(runnerParameters[UnityConstants.PARAM_PROJECT_PATH])
+                val projectFile = File(it.trim())
                 workingDirectory = projectFile.absolutePath
             }
         }

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -28,12 +28,14 @@ class UnityRunnerBuildService : BuildServiceAdapter() {
         val toolPath = getToolPath(UnityConstants.RUNNER_TYPE)
         val arguments = mutableListOf("-batchmode")
 
+        var workingDirectory = workingDirectory.absolutePath
         runnerParameters[UnityConstants.PARAM_PROJECT_PATH]?.let {
             if (it.isNotEmpty()) {
-                val projectDir = File(workingDirectory, it.trim())
-                arguments.addAll(listOf("-projectPath", projectDir.absolutePath))
+                val projectFile = File(runnerParameters[UnityConstants.PARAM_PROJECT_PATH])
+                workingDirectory = projectFile.absolutePath
             }
         }
+        arguments.addAll(listOf("-projectPath", workingDirectory))
 
         runnerParameters[UnityConstants.PARAM_BUILD_TARGET]?.let {
             if (it.isNotEmpty()) {

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -28,14 +28,13 @@ class UnityRunnerBuildService : BuildServiceAdapter() {
         val toolPath = getToolPath(UnityConstants.RUNNER_TYPE)
         val arguments = mutableListOf("-batchmode")
 
-        var workingDirectory = workingDirectory.absolutePath
+        var projectDir = workingDirectory
         runnerParameters[UnityConstants.PARAM_PROJECT_PATH]?.let {
             if (it.isNotEmpty()) {
-                val projectFile = File(it.trim())
-                workingDirectory = projectFile.absolutePath
+                projectDir = File(it.trim())
             }
         }
-        arguments.addAll(listOf("-projectPath", workingDirectory))
+        arguments.addAll(listOf("-projectPath", projectDir.absolutePath))
 
         runnerParameters[UnityConstants.PARAM_BUILD_TARGET]?.let {
             if (it.isNotEmpty()) {

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -64,7 +64,7 @@
         </props:textProperty>
         <span class="error" id="error_${params.projectPath}"></span>
         <span class="smallNote">
-            <span id="${params.projectPath}">Specify the path to the target project.</span>
+            <span id="${params.projectPath}">Specify the path to the target project, if unspecified, we will use the working directory</span>
         </span>
     </td>
 </tr>

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -64,7 +64,7 @@
         </props:textProperty>
         <span class="error" id="error_${params.projectPath}"></span>
         <span class="smallNote">
-            <span id="${params.projectPath}">Specify the path to the target project, if unspecified, we will use the working directory</span>
+            <span id="${params.projectPath}">Specify the path to the target project. If unspecified, will be used the working directory.</span>
         </span>
     </td>
 </tr>


### PR DESCRIPTION
If you do not provide a projectPath to unity it will open the last opened project, which I think is behaviour no one would want, with this modification, we always force a projectPath (and i've updated the helper text in the jsp to elaborate on that)

By default we always tell unity to open at the working directory when a project path is not specified, which would be the checkout directory and seems like a sensible option.

There was also a bug whereby Project Path would be appended twice, when specifying a project path.
I.E. C/thing/anotherthing/C/thing/anotherthing (which obviously didn't work)