### PR TITLE
Ensure we pull the first compatible version, which would be the versi…

### DIFF
--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
@@ -114,7 +114,7 @@ class UnityToolProvider(toolsRegistry: ToolProvidersRegistry,
             unityVersions.entries.lastOrNull()
         } else {
             val upperVersion = getUpperVersion(unityVersion)
-            unityVersions.entries.lastOrNull {
+            unityVersions.entries.firstOrNull {
                 it.key >= unityVersion && it.key < upperVersion
             }
         } ?: throw ToolCannotBeFoundException("""


### PR DESCRIPTION
Ensure we pull the first compatible version, which would be the version we actually want, that matches directly with the version requested, rather than the last matching version, which in the case of many unity installations will be a version higher than the one requested.