### PR TITLE
With this being escaped, builds can't run due to unmet requirements o…

### DIFF
--- a/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerRunType.kt
+++ b/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerRunType.kt
@@ -94,12 +94,12 @@ class UnityRunnerRunType(private val myPluginDescriptor: PluginDescriptor,
         val requirements = mutableListOf<Requirement>()
         parameters[UnityConstants.PARAM_UNITY_VERSION]?.let {
             if (it.isNotBlank()) {
-                val name = escapeRegex(UnityConstants.UNITY_CONFIG_NAME + it.trim()) + ".*"
+                val name = UnityConstants.UNITY_CONFIG_NAME + it.trim() + ".*"
                 requirements.add(Requirement(RequirementQualifier.EXISTS_QUALIFIER + name, null, RequirementType.EXISTS))
             }
         }
         if (requirements.isEmpty()) {
-            val name = escapeRegex(UnityConstants.UNITY_CONFIG_NAME) + ".+"
+            val name = UnityConstants.UNITY_CONFIG_NAME + ".+"
             requirements.add(Requirement(RequirementQualifier.EXISTS_QUALIFIER + name, null, RequirementType.EXISTS))
         }
         return requirements


### PR DESCRIPTION
With this being escaped, builds can't run due to unmet requirements on....

2018./3./2 <--- For example

I appreciate just removing this code fixes my issue but the code was obviously there for a reason, I'm pushing this for reference only. With this change, tests rightly fail, I'm not sure what the correct fix is here.