### PR TITLE
Custom log path

### DIFF
--- a/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
+++ b/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
@@ -43,6 +43,7 @@ object UnityConstants {
     const val PARAM_TEST_NAMES = "testNames"
     const val PARAM_SILENT_CRASHES = "silentCrashes"
     const val PARAM_LINE_STATUSES_FILE = "lineStatusesFile"
+    const val PARAM_UNITY_LOG_FILE = "logFilePath"
     const val PARAM_VERBOSITY = "verbosity"
 
     const val PARAM_ACTIVATE_LICENSE = "activateLicense"

--- a/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
+++ b/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
@@ -62,6 +62,9 @@ class UnityParametersProvider {
     val lineStatusesFile: String
         get() = UnityConstants.PARAM_LINE_STATUSES_FILE
 
+    val logFilePath: String
+        get() = UnityConstants.PARAM_UNITY_LOG_FILE
+
     val activateLicense: String
         get() = UnityConstants.PARAM_ACTIVATE_LICENSE
 

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -243,6 +243,15 @@
 </tr>
 
 <tr class="advancedSetting">
+    <th><label for="${params.logFilePath}">Unity version:</label></th>
+    <td>
+        <props:textProperty name="${params.logFilePath}" className="longField disableBuildTypeParams"/>
+        <span class="error" id="error_${params.logFilePath}"></span>
+        <span class="smallNote">Path for Unity log file</span>
+    </td>
+</tr>
+
+<tr class="advancedSetting">
     <th><label for="${params.verbosity}">Logging verbosity:</label></th>
     <td>
         <props:selectProperty name="${params.verbosity}" enableFilter="true" className="mediumField">

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -243,7 +243,7 @@
 </tr>
 
 <tr class="advancedSetting">
-    <th><label for="${params.logFilePath}">Unity version:</label></th>
+    <th><label for="${params.logFilePath}">Custom log path:</label></th>
     <td>
         <props:textProperty name="${params.logFilePath}" className="longField disableBuildTypeParams"/>
         <span class="error" id="error_${params.logFilePath}"></span>

--- a/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
@@ -103,6 +103,12 @@
     </div>
 </c:if>
 
+<c:if test="${not empty propertiesBean.properties[params.logFilePath]}">
+    <div class="parameter">
+        Log file path: <props:displayValue name="${params.logFilePath}"/>
+    </div>
+</c:if>
+
 <c:if test="${not empty propertiesBean.properties[params.verbosity]}">
     <div class="parameter">
         <c:forEach items="${params.verbosityValues}" var="type">


### PR DESCRIPTION
Sometimes you need a log. Also inside the Unity, some plugins read the log from the "-logFile" attribute.
If the field is empty, then everything will work as usual, if filled, then the log will be saved at the specified path.