### PR TITLE
Added unityExecutable field to support agent tools properly

### DIFF
--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityToolProvider.kt
@@ -107,7 +107,14 @@ class UnityToolProvider(toolsRegistry: ToolProvidersRegistry,
         }
 
         val unityVersion = getUnityVersion(runner, build)
-        return getUnity(toolName, unityVersion)
+        var explicitExecutable = runner.runnerParameters[UnityConstants.PARAM_UNITY_EXECUTABLE]?.trim()
+        if (explicitExecutable.isNullOrEmpty())
+            return getUnity(toolName, unityVersion)
+
+        if (unityVersion == null) {
+            return Semver("2019.1.0") to explicitExecutable
+        }
+        return unityVersion to explicitExecutable
     }
 
     private fun getUnity(toolName: String, unityVersion: Semver?): Pair<Semver, String> {

--- a/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
+++ b/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
@@ -37,6 +37,7 @@ object UnityConstants {
     const val PARAM_NO_GRAPHICS = "noGraphics"
     const val PARAM_ARGUMENTS = "arguments"
     const val PARAM_UNITY_VERSION = "unityVersion"
+    const val PARAM_UNITY_EXECUTABLE = "unityExecutable"
     const val PARAM_RUN_EDITOR_TESTS = "runEditorTests"
     const val PARAM_TEST_PLATFORM = "testPlatform"
     const val PARAM_TEST_CATEGORIES = "testCategories"

--- a/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
+++ b/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
@@ -38,6 +38,9 @@ class UnityParametersProvider {
     val unityVersion: String
         get() = UnityConstants.PARAM_UNITY_VERSION
 
+    val unityExecutable: String
+        get() = UnityConstants.PARAM_UNITY_EXECUTABLE
+
     val noGraphics: String
         get() = UnityConstants.PARAM_NO_GRAPHICS
 

--- a/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerRunType.kt
+++ b/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerRunType.kt
@@ -101,6 +101,12 @@ class UnityRunnerRunType(private val myPluginDescriptor: PluginDescriptor,
 
     override fun getRunnerSpecificRequirements(parameters: Map<String, String>): List<Requirement> {
         val requirements = mutableListOf<Requirement>()
+        parameters[UnityConstants.PARAM_UNITY_EXECUTABLE]?.let {
+            if (it.isNotBlank()) {
+                return requirements
+            }
+        }
+
         parameters[UnityConstants.PARAM_UNITY_VERSION]?.let {
             if (it.isNotBlank()) {
                 val name = escapeRegex(UnityConstants.UNITY_CONFIG_NAME + it.trim()) + ".*"

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -225,6 +225,15 @@
 </tr>
 
 <tr class="advancedSetting">
+    <th><label for="${params.unityExecutable}">Unity executable:</label></th>
+    <td>
+        <props:textProperty name="${params.unityExecutable}" className="longField"/>
+        <span class="error" id="error_${params.unityExecutable}"></span>
+        <span class="smallNote">Specify a direct path to the unity executable. Normally used to deploy Unity using agent tool or to provide a proxy executable in vcs.</span>
+    </td>
+</tr>
+
+<tr class="advancedSetting">
     <th>
         <label for="${params.lineStatusesFile}">Line statuses file: <bs:help
             urlPrefix="https://github.com/JetBrains/teamcity-unity-plugin#custom-error-logging-settings" file=""/></label>

--- a/plugin-unity-server/src/test/kotlin/jetbrains/buildServer/unity/fetchers/UnityRunnerRunTypeTest.kt
+++ b/plugin-unity-server/src/test/kotlin/jetbrains/buildServer/unity/fetchers/UnityRunnerRunTypeTest.kt
@@ -40,8 +40,11 @@ class UnityRunnerRunTypeTest {
                 arrayOf<Any?>(
                         mapOf(UnityConstants.PARAM_UNITY_VERSION to "2018.2"),
                         listOf(Requirement("Exists=>unity\\.path\\.2018\\.2.*", null, RequirementType.EXISTS))
+                ),
+                arrayOf<Any?>(
+                        mapOf(UnityConstants.PARAM_UNITY_VERSION to "2018.2", UnityConstants.PARAM_UNITY_EXECUTABLE to "%system.teamcity.build.checkoutDir%\\SayHello.exe"),
+                        emptyList<Requirement>())
                 )
-        )
     }
 
     @Test(dataProvider = "runnerRequirementsData")


### PR DESCRIPTION
Added field unityExecutable. Allows specifying Unity path on agent explicitly. If set, no requirements are registered. UnityVersion field is used to know what the executable supports but is optional.

This makes it possible to

Install Unity using agent tool and using it without any dependencies. Eg:
%teamcity.tool.unity_master%\Editor\Unity.exe
Have Unity executable or proxy executable in VCS.
Have a fixed Unity installation on all agents.
I have no idea what language I just coded in!
Might require some adjustments to be useful on different OSs?