### PR TITLE
Option to remove "-quit" argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for running Unity inside a container starting from 2023.09 TeamCity version
 - Support for Unity Personal license activation via .ulf file upload
+- Add option to remove '-quit' argument
 
 ## 1.0.4 - 2023-05-03
 

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityBuildSessionFactory.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityBuildSessionFactory.kt
@@ -38,6 +38,7 @@ class UnityBuildSessionFactory(
     override fun createSession(runnerContext: BuildRunnerContext): MultiCommandBuildSession =
         UnityCommandBuildSession(
             runnerContext,
+            fileSystemService,
             unityEnvironmentProvider(runnerContext),
             unityLicenseManager(runnerContext),
         )

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityCommandBuildSession.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityCommandBuildSession.kt
@@ -21,9 +21,11 @@ import jetbrains.buildServer.agent.BuildRunnerContext
 import jetbrains.buildServer.agent.runner.CommandExecution
 import jetbrains.buildServer.agent.runner.MultiCommandBuildSession
 import jetbrains.buildServer.unity.license.UnityLicenseManager
+import jetbrains.buildServer.unity.util.FileSystemService
 
 class UnityCommandBuildSession(
     private val runnerContext: BuildRunnerContext,
+    private val fileSystemService: FileSystemService,
     private val unityEnvironmentProvider: UnityEnvironmentProvider,
     private val unityLicenseManager: UnityLicenseManager,
 ) : MultiCommandBuildSession {
@@ -72,7 +74,7 @@ class UnityCommandBuildSession(
     private suspend fun SequenceScope<CommandExecution>.executeBuild() {
         yieldAll(
             UnityRunnerBuildService
-                .createAdapters(unityEnvironmentProvider.unityEnvironment(), runnerContext)
+                .createAdapters(unityEnvironmentProvider.unityEnvironment(), runnerContext, fileSystemService)
                 .map {
                     it.initialize(runnerContext.build, runnerContext)
                     val command = BuildCommandExecutionAdapter(it)

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -87,7 +87,7 @@ class UnityRunnerBuildService(
     override fun makeProgramCommandLine(): ProgramCommandLine {
         val unityVersion = unityEnvironment.unityVersion
         val unityPath = unityEnvironment.unityPath
-        val arguments = mutableListOf("-batchmode")
+        val arguments = mutableListOf("-batchmode", ARG_QUIT)
 
         var projectPath = "./"
         parameters.value[UnityConstants.PARAM_PROJECT_PATH]?.let {
@@ -138,9 +138,9 @@ class UnityRunnerBuildService(
             }
         }
 
-        parameters.value[UnityConstants.PARAM_QUIT]?.let {
+        parameters.value[UnityConstants.PARAM_NO_QUIT]?.let {
             if (it.toBoolean()) {
-                arguments.add(ARG_QUIT)
+                arguments.remove(ARG_QUIT)
             }
         }
 

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -138,6 +138,12 @@ class UnityRunnerBuildService(
             }
         }
 
+        parameters.value[UnityConstants.PARAM_QUIT]?.let {
+            if (it.toBoolean()) {
+                arguments.add(ARG_QUIT)
+            }
+        }
+
         parameters.value[UnityConstants.PARAM_EXECUTE_METHOD]?.let {
             if (it.isNotEmpty()) {
                 arguments.addAll(listOf("-executeMethod", it.trim()))
@@ -177,10 +183,12 @@ class UnityRunnerBuildService(
         val runTests = parameters.value[UnityConstants.PARAM_RUN_EDITOR_TESTS]?.toBoolean() ?: false
         val testPlatform = parameters.value[UnityConstants.PARAM_TEST_PLATFORM]
 
-        // For tests run we should not add -quit argument
         val runTestIndex = arguments.indexOfFirst { RUN_TESTS_REGEX.matches(it) }
         if (runTestIndex < 0) {
             if (runTests) {
+                // For tests run we should remove -quit argument
+                arguments.remove(ARG_QUIT);
+
                 // Append -runTests argument if selected test platform
                 // otherwise use -runEditorTests argument
                 if (testPlatform.isNullOrEmpty()) {
@@ -189,7 +197,6 @@ class UnityRunnerBuildService(
                     arguments.addAll(listOf(ARG_RUN_TESTS, "-testPlatform", testPlatform))
                 }
             } else {
-                arguments.add("-quit")
                 return
             }
         }
@@ -323,6 +330,7 @@ class UnityRunnerBuildService(
         private const val ARG_EDITOR_TESTS_RESULT_FILE = "-editorTestsResultFile"
         private const val ARG_LOG_FILE = "-logFile"
         private const val ARG_NO_GRAPHICS = "-nographics"
+        private const val ARG_QUIT= "-quit"
         private const val LOG_FILE_ACCESS_MODE = "rw"
         private val RUN_TESTS_REGEX = Regex("-run(Editor)?Tests")
         private val RUN_TEST_RESULTS_REGEX = Regex("-(editorTestsResultFile|testResults)")

--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/util/FileSystemService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/util/FileSystemService.kt
@@ -8,9 +8,9 @@ import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 class FileSystemService {
-    fun createFile(path: String): Path = Path.of(path)
+    fun createPath(path: String): Path = Path.of(path)
 
-    fun createFile(parent: Path, child: String): Path = Path.of(parent.absolutePathString(), child)
+    fun createPath(parent: Path, child: String): Path = Path.of(parent.absolutePathString(), child)
 
     fun createTempFile(directory: Path, prefix: String, suffix: String): Path {
         return Files.createTempFile(directory, prefix, suffix)

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityBuildSessionFactoryTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityBuildSessionFactoryTest.kt
@@ -22,26 +22,26 @@ class UnityBuildSessionFactoryTest {
 
     @Test
     fun `should create unity command build session`() {
-        // given
+        // arrange
         val factory = createInstance()
         val runnerContext = mockk<BuildRunnerContext>()
 
-        // when
+        // act
         val session = factory.createSession(runnerContext)
 
-        // then
+        // assert
         session.shouldBeInstanceOf<UnityCommandBuildSession>()
     }
 
     @Test
     fun `should return correct build runner info`() {
-        // given
+        // arrange
         val factory = createInstance()
 
-        // when
+        // act
         val buildRunnerInfo = factory.buildRunnerInfo
 
-        // then
+        // assert
         buildRunnerInfo.type shouldBeEqual "unity"
         buildRunnerInfo.canRun(mockk()) shouldBe true
     }

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityCommandBuildSessionTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityCommandBuildSessionTest.kt
@@ -12,239 +12,251 @@ import jetbrains.buildServer.unity.detectors.DetectVirtualUnityEnvironmentComman
 import jetbrains.buildServer.unity.license.ActivateProLicenseCommand
 import jetbrains.buildServer.unity.license.ReturnProLicenseCommand
 import jetbrains.buildServer.unity.license.UnityLicenseManager
+import jetbrains.buildServer.unity.util.FileSystemService
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 class UnityCommandBuildSessionTest {
 
-    private val runnerContext = mockk<BuildRunnerContext>()
-    private val envProvider = mockk<UnityEnvironmentProvider>()
-    private val licenceManager = mockk<UnityLicenseManager>()
+    private val runnerContextMock = mockk<BuildRunnerContext>()
+    private val fileSystemServiceMock = mockk<FileSystemService>()
+    private val envProviderMock = mockk<UnityEnvironmentProvider>()
+    private val licenceManagerMock = mockk<UnityLicenseManager>()
 
-    private val unityEnvironment = mockk<UnityEnvironment>()
+    private val unityEnvironmentMock = mockk<UnityEnvironment>()
 
     @BeforeMethod
     fun setUp() {
         clearAllMocks()
 
-        every { envProvider.unityEnvironment() } returns unityEnvironment
+        every { envProviderMock.unityEnvironment() } returns unityEnvironmentMock
     }
 
     @Test
     fun `should detect virtual unity environment as the 1st command`() {
-        // given
+        // arrange
         val session = startedSession()
         val detectCommand = givenDetectVirtualUnityEnvironmentCommand()
 
-        // when
+        // act
         val command = getNthCommand(1, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command!! shouldBeEqual detectCommand
 
-        verify(exactly = 1) { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() wasNot Called }
-        verify { licenceManager wasNot Called }
+        verify(exactly = 1) { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() wasNot Called }
+        verify { licenceManagerMock wasNot Called }
     }
 
     @Test
     fun `should activate license as the 1st command`() {
-        // given
+        // arrange
         val session = startedSession()
         givenNoDetectVirtualUnityEnvironmentCommand()
         val activateLicenseCommand = givenActivateLicenseCommand()
 
-        // when
+        // act
         val command = getNthCommand(1, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command!! shouldBeEqual activateLicenseCommand
 
-        verify(exactly = 1) { envProvider.provide(runnerContext) }
-        verify(exactly = 1) { envProvider.unityEnvironment() }
-        verify(exactly = 1) { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify(exactly = 1) { envProviderMock.provide(runnerContextMock) }
+        verify(exactly = 1) { envProviderMock.unityEnvironment() }
+        verify(exactly = 1) {
+            licenceManagerMock.activateLicense(
+                envProviderMock.unityEnvironment(),
+                runnerContextMock
+            )
+        }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should activate license as the 2nd command`() {
-        // given
+        // arrange
         val session = startedSession()
         givenDetectVirtualUnityEnvironmentCommand()
         val activateLicenseCommand = givenActivateLicenseCommand()
 
-        // when
+        // act
         val command = getNthCommand(2, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command!! shouldBeEqual activateLicenseCommand
 
-        verify(exactly = 1) { envProvider.provide(runnerContext) }
-        verify(exactly = 1) { envProvider.unityEnvironment() }
-        verify(exactly = 1) { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify(exactly = 1) { envProviderMock.provide(runnerContextMock) }
+        verify(exactly = 1) { envProviderMock.unityEnvironment() }
+        verify(exactly = 1) {
+            licenceManagerMock.activateLicense(
+                envProviderMock.unityEnvironment(),
+                runnerContextMock
+            )
+        }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should execute build as the 1st command`() {
-        // given
+        // arrange
         val session = startedSession()
-        every { runnerContext.runnerParameters } returns emptyMap()
-        every { runnerContext.build } returns mockk(relaxed = true)
+        every { runnerContextMock.runnerParameters } returns emptyMap()
+        every { runnerContextMock.build } returns mockk(relaxed = true)
 
         givenNoDetectVirtualUnityEnvironmentCommand()
         givenNoLicenseCommands()
 
-        // when
+        // act
         val command = getNthCommand(1, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
 
-        verify { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() }
-        verify { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() }
+        verify { licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should execute build as the 2nd command`() {
-        // given
+        // arrange
         val session = startedSession()
-        every { runnerContext.runnerParameters } returns emptyMap()
-        every { runnerContext.build } returns mockk(relaxed = true)
+        every { runnerContextMock.runnerParameters } returns emptyMap()
+        every { runnerContextMock.build } returns mockk(relaxed = true)
 
         givenNoDetectVirtualUnityEnvironmentCommand()
         givenActivateLicenseCommand()
 
-        // when
+        // act
         val command = getNthCommand(2, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
 
-        verify { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() }
-        verify { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() }
+        verify { licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should execute build as the 3d command`() {
-        // given
+        // arrange
         val session = startedSession()
-        every { runnerContext.runnerParameters } returns emptyMap()
-        every { runnerContext.build } returns mockk(relaxed = true)
+        every { runnerContextMock.runnerParameters } returns emptyMap()
+        every { runnerContextMock.build } returns mockk(relaxed = true)
 
         givenDetectVirtualUnityEnvironmentCommand()
         givenActivateLicenseCommand()
 
-        // when
+        // act
         val command = getNthCommand(3, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
 
-        verify { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() }
-        verify { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() }
+        verify { licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should execute build as the 1st and the 2nd commands when all test platforms specified`() {
-        // given
+        // arrange
         val session = startedSession()
-        every { runnerContext.runnerParameters } returns mapOf(PARAM_TEST_PLATFORM to "all")
-        every { runnerContext.build } returns mockk(relaxed = true)
+        every { runnerContextMock.runnerParameters } returns mapOf(PARAM_TEST_PLATFORM to "all")
+        every { runnerContextMock.build } returns mockk(relaxed = true)
 
         givenNoDetectVirtualUnityEnvironmentCommand()
         givenNoLicenseCommands()
 
-        // when
+        // act
         val firstCommand = session.nextCommand
         val secondCommand = session.nextCommand
 
-        // then
+        // assert
         firstCommand shouldNotBe null
         firstCommand?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
         secondCommand shouldNotBe null
         secondCommand?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
 
-        verify { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() }
-        verify { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() }
+        verify { licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should execute build as the 3d and the 4th commands when all test platforms specified`() {
-        // given
+        // arrange
         val session = startedSession()
-        every { runnerContext.runnerParameters } returns mapOf(PARAM_TEST_PLATFORM to "all")
-        every { runnerContext.build } returns mockk(relaxed = true)
+        every { runnerContextMock.runnerParameters } returns mapOf(PARAM_TEST_PLATFORM to "all")
+        every { runnerContextMock.build } returns mockk(relaxed = true)
 
         givenDetectVirtualUnityEnvironmentCommand()
         givenActivateLicenseCommand()
 
-        // when
+        // act
         val thirdCommand = getNthCommand(3, session)
         val fourthCommand = session.nextCommand
 
-        // then
+        // assert
         thirdCommand shouldNotBe null
         thirdCommand?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
         fourthCommand shouldNotBe null
         fourthCommand?.shouldBeInstanceOf<BuildCommandExecutionAdapter>()
 
-        verify { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() }
-        verify { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(any(), any()) wasNot Called }
+        verify { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() }
+        verify { licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
+        verify { licenceManagerMock.returnLicense(any(), any()) wasNot Called }
     }
 
     @Test
     fun `should return unity license as the last command`() {
-        // given
+        // arrange
         val session = startedSession()
-        every { runnerContext.runnerParameters } returns mapOf(PARAM_TEST_PLATFORM to "all")
-        every { runnerContext.build } returns mockk(relaxed = true)
+        every { runnerContextMock.runnerParameters } returns mapOf(PARAM_TEST_PLATFORM to "all")
+        every { runnerContextMock.build } returns mockk(relaxed = true)
         givenDetectVirtualUnityEnvironmentCommand()
         givenActivateLicenseCommand()
         val returnLicenseCommand = givenReturnLicenseCommand()
 
-        // when
+        // act
         val command = getNthCommand(5, session)
 
-        // then
+        // assert
         command shouldNotBe null
         command!! shouldBeEqual returnLicenseCommand
 
-        verify { envProvider.provide(runnerContext) }
-        verify { envProvider.unityEnvironment() }
-        verify { licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext) }
-        verify { licenceManager.returnLicense(envProvider.unityEnvironment(), runnerContext) }
+        verify { envProviderMock.provide(runnerContextMock) }
+        verify { envProviderMock.unityEnvironment() }
+        verify { licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
+        verify { licenceManagerMock.returnLicense(envProviderMock.unityEnvironment(), runnerContextMock) }
     }
 
     @Test
     fun `should do nothing on nextCommand if sessionStarted was not called (should not happen)`() {
-        // given
+        // arrange
         val session = createInstance()
 
-        // when
+        // act
         val nextCommand = session.nextCommand
 
-        // then
+        // assert
         nextCommand shouldBe null
 
-        verify { envProvider wasNot Called }
-        verify { licenceManager wasNot Called }
+        verify { envProviderMock wasNot Called }
+        verify { licenceManagerMock wasNot Called }
     }
 
     private fun startedSession(): UnityCommandBuildSession {
@@ -255,18 +267,18 @@ class UnityCommandBuildSessionTest {
 
     private fun givenDetectVirtualUnityEnvironmentCommand(): DetectVirtualUnityEnvironmentCommand {
         val command = mockk<DetectVirtualUnityEnvironmentCommand>()
-        every { envProvider.provide(runnerContext) } returns sequenceOf(command)
+        every { envProviderMock.provide(runnerContextMock) } returns sequenceOf(command)
         return command
     }
 
     private fun givenNoDetectVirtualUnityEnvironmentCommand() {
-        every { envProvider.provide(runnerContext) } returns emptySequence()
+        every { envProviderMock.provide(runnerContextMock) } returns emptySequence()
     }
 
     private fun givenActivateLicenseCommand(): ActivateProLicenseCommand {
         val command = mockk<ActivateProLicenseCommand>()
         every {
-            licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext)
+            licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock)
         } returns sequenceOf(command)
         return command
     }
@@ -274,17 +286,17 @@ class UnityCommandBuildSessionTest {
     private fun givenReturnLicenseCommand(): ReturnProLicenseCommand {
         val command = mockk<ReturnProLicenseCommand>()
         every {
-            licenceManager.returnLicense(envProvider.unityEnvironment(), runnerContext)
+            licenceManagerMock.returnLicense(envProviderMock.unityEnvironment(), runnerContextMock)
         } returns sequenceOf(command)
         return command
     }
 
     private fun givenNoLicenseCommands() {
         every {
-            licenceManager.activateLicense(envProvider.unityEnvironment(), runnerContext)
+            licenceManagerMock.activateLicense(envProviderMock.unityEnvironment(), runnerContextMock)
         } returns emptySequence()
         every {
-            licenceManager.returnLicense(envProvider.unityEnvironment(), runnerContext)
+            licenceManagerMock.returnLicense(envProviderMock.unityEnvironment(), runnerContextMock)
         } returns emptySequence()
     }
 
@@ -297,8 +309,9 @@ class UnityCommandBuildSessionTest {
     }
 
     private fun createInstance() = UnityCommandBuildSession(
-        runnerContext,
-        envProvider,
-        licenceManager,
+        runnerContextMock,
+        fileSystemServiceMock,
+        envProviderMock,
+        licenceManagerMock,
     )
 }

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityEnvironmentProviderTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityEnvironmentProviderTest.kt
@@ -25,18 +25,18 @@ class UnityEnvironmentProviderTest {
 
     @Test
     fun `should initialize unity environment when context is NOT virtual`() {
-        // given
+        // arrange
         val provider = createInstance()
         val context = mockk<BuildRunnerContext>()
         val unityEnvironment = mockk<UnityEnvironment>()
         every { context.isVirtualContext } returns false
         every { unityToolProvider.getUnity(any(), any()) } returns unityEnvironment
 
-        // when
+        // act
         val command = provider.provide(context).firstOrNull()
         val result = provider.unityEnvironment()
 
-        // then
+        // assert
         command shouldBe null
         result shouldBe unityEnvironment
 
@@ -46,18 +46,18 @@ class UnityEnvironmentProviderTest {
 
     @Test
     fun `should initialize unity environment when context is virtual`() {
-        // given
+        // arrange
         val provider = createInstance()
         val context = mockk<BuildRunnerContext>()
         val unityEnvironment = mockk<UnityEnvironment>()
         every { context.isVirtualContext } returns true
         every { detectCommand.results } returns mutableSetOf(unityEnvironment)
 
-        // when
+        // act
         val commands = provider.provide(context).toList()
         val result = provider.unityEnvironment()
 
-        // then
+        // assert
         commands shouldHaveSize 1
         commands shouldContain detectCommand
         result shouldBeEqual unityEnvironment
@@ -68,10 +68,10 @@ class UnityEnvironmentProviderTest {
 
     @Test
     fun `should throw exception when unity environment is not initialized`() {
-        // given
+        // arrange
         val provider = createInstance()
 
-        // when // then
+        // act // assert
         shouldThrowExactly<ToolCannotBeFoundException> {
             provider.unityEnvironment()
         }.message shouldBe "Unity environment is not initialized yet"
@@ -79,13 +79,13 @@ class UnityEnvironmentProviderTest {
 
     @Test
     fun `should fail to initialize unity environment when context is virtual and no environment detected`() {
-        // given
+        // arrange
         val provider = createInstance()
         val context = mockk<BuildRunnerContext>()
         every { context.isVirtualContext } returns true
         every { detectCommand.results } returns mutableSetOf()
 
-        // when // then
+        // act // assert
         shouldThrowExactly<ToolCannotBeFoundException> {
             provider.provide(context).toList()
         }.message shouldBe "Failed to detect Unity virtual environment"

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildServiceTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildServiceTest.kt
@@ -180,8 +180,8 @@ class UnityRunnerBuildServiceTest {
         // assert
         commandLine shouldNotBe null
         val commandString = commandLine.arguments.joinToString(" ")
-        commandString shouldBeEqual "-batchmode -quit -projectPath /converted/project " +
-                "-player /converted/player -nographics -logFile /converted/logs"
+        commandString shouldBeEqual "-batchmode -projectPath /converted/project " +
+                "-player /converted/player -nographics -quit -logFile /converted/logs"
     }
 
     private inner class FakeUnityBuildFeature(

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildServiceTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildServiceTest.kt
@@ -128,7 +128,7 @@ class UnityRunnerBuildServiceTest {
         commandLine shouldNotBe null
         val commandString = commandLine.arguments.joinToString(" ")
         commandString shouldBeEqual "-batchmode -projectPath /converted/project " +
-                "-player /converted/player -nographics -quit -logFile /converted/logs"
+                "-player /converted/player -nographics -logFile /converted/logs"
     }
 
     private inner class FakeUnityBuildFeature(

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildServiceTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildServiceTest.kt
@@ -127,7 +127,7 @@ class UnityRunnerBuildServiceTest {
         // assert
         commandLine shouldNotBe null
         val commandString = commandLine.arguments.joinToString(" ")
-        commandString shouldBeEqual "-batchmode -projectPath /converted/project " +
+        commandString shouldBeEqual "-batchmode -quit -projectPath /converted/project " +
                 "-player /converted/player -nographics -logFile /converted/logs"
     }
 

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/detectors/DetectVirtualUnityEnvironmentCommandTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/detectors/DetectVirtualUnityEnvironmentCommandTest.kt
@@ -101,13 +101,13 @@ class DetectVirtualUnityEnvironmentCommandTest {
 
     @Test(dataProvider = "correct standard output")
     fun `should parse correct standard output`(stdout: String, expectedEnvironment: Set<UnityEnvironment>) {
-        // given
+        // arrange
         val command = createInstance()
 
-        // when
+        // act
         command.onStandardOutput(stdout)
 
-        // then
+        // assert
         command.results shouldContainExactly expectedEnvironment
     }
 
@@ -125,42 +125,42 @@ class DetectVirtualUnityEnvironmentCommandTest {
 
     @Test(dataProvider = "wrong standard output")
     fun `should not fail on wrong standard output`(stdout: String) {
-        // given
+        // arrange
         val command = createInstance()
 
-        // when
+        // act
         command.onStandardOutput(stdout)
 
-        // then
+        // assert
         command.results.shouldBeEmpty()
     }
 
     @Test
     fun `should skip detected Unity environment if an expected Unity version is different in params`() {
-        // given
+        // arrange
         val command = createInstance()
         val stdout = "path=/path/to/1/Unity;version=2023.0.1\npath=/path/to/2/Unity;version=2023.0.2\n"
 
         every { runnerContext.unityVersionParam() } returns parseVersion("2023.0.1")
 
-        // when
+        // act
         command.onStandardOutput(stdout)
 
-        // then
+        // assert
         command.results shouldHaveSize 1
         command.results shouldContain UnityEnvironment("/path/to/1/Unity", parseVersion("2023.0.1"), true)
     }
 
     @Test
     fun `should not create duplicate Unity environment in case of duplicate stdout`() {
-        // given
+        // arrange
         val command = createInstance()
         val stdout = "path=/path/to/Unity;version=2023.0.1\npath=/path/to/Unity;version=2023.0.1\n"
 
-        // when
+        // act
         command.onStandardOutput(stdout)
 
-        // then
+        // assert
         command.results shouldHaveSize 1
         command.results shouldContain UnityEnvironment("/path/to/Unity", parseVersion("2023.0.1"), true)
     }
@@ -174,16 +174,16 @@ class DetectVirtualUnityEnvironmentCommandTest {
 
     @Test(dataProvider = "OS type to expected script name")
     fun `should make program command line`(osType: OSType, expectedScriptName: String) {
-        // given
+        // arrange
         val command = createInstance()
 
         every { virtualContext.targetOSType } returns osType
         every { runnerContext.buildParameters.environmentVariables } returns mapOf("ENV" to "VALUE")
 
-        // when
+        // act
         val commandLine = command.makeProgramCommandLine()
 
-        // then
+        // assert
         commandLine.shouldBeInstanceOf<SimpleProgramCommandLine>()
         commandLine.environment shouldContainExactly mapOf("ENV" to "VALUE")
         commandLine.workingDirectory shouldBeEqual "path"
@@ -193,16 +193,16 @@ class DetectVirtualUnityEnvironmentCommandTest {
 
     @Test
     fun `should make program command line passing unity root ENV variable from params`() {
-        // given
+        // arrange
         val command = createInstance()
 
         every { runnerContext.buildParameters.environmentVariables } returns mapOf("ENV" to "VALUE")
         every { runnerContext.unityRootParam() } returns "/path/to/unity"
 
-        // when
+        // act
         val commandLine = command.makeProgramCommandLine()
 
-        // then
+        // assert
         commandLine.environment shouldContainExactly mapOf(
             "ENV" to "VALUE",
             "UNITY_ROOT_PARAMETER" to "/path/to/unity"

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/detectors/UnityToolProviderTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/detectors/UnityToolProviderTest.kt
@@ -44,28 +44,28 @@ class UnityToolProviderTest {
 
     @Test
     fun `should throw exception if wrong tool name is provided`() {
-        // given
+        // arrange
         val provider = createInstance()
 
-        // when // then
+        // act // assert
         shouldThrowExactly<ToolCannotBeFoundException> { provider.getUnity("wrong tool name") }
             .message?.shouldBeEqual("Unsupported tool wrong tool name")
     }
 
     @Test
     fun `should throw exception when unity detector was not created`() {
-        // given
+        // arrange
         every { unityDetectorFactory.unityDetector() } returns null
         val provider = createInstance()
 
-        // when // then
+        // act // assert
         shouldThrowExactly<ToolCannotBeFoundException> { provider.getUnity("unity") }
             .message?.shouldBeEqual("unity")
     }
 
     @Test
     fun `should detect unity environment when unity root param is provided`() {
-        // given
+        // arrange
         val provider = createInstance()
         val unityRootParam = "/path/to/unity"
         val unityVersion = UnityVersion(2023, 1, 1)
@@ -73,10 +73,10 @@ class UnityToolProviderTest {
         every { unityDetector.getVersionFromInstall(File(unityRootParam)) } returns unityVersion
         every { unityDetector.getEditorPath(File(unityRootParam)) } returns File("$unityRootParam/Unity")
 
-        // when
+        // act
         val result = provider.getUnity("unity", runnerContext)
 
-        // then
+        // assert
         result shouldBeEqual UnityEnvironment(File("$unityRootParam/Unity").absolutePath, unityVersion, false)
     }
 

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/ActivatePersonalLicenseCommandTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/ActivatePersonalLicenseCommandTest.kt
@@ -53,7 +53,7 @@ class ActivatePersonalLicenseCommandTest {
 
     @Test
     fun `should make program command line`() {
-        // given
+        // arrange
         val command = createInstance()
         val licenseFilePath = "/path/to/license/file.ulf"
         val logFilePath = "/path/to/logs.txt"
@@ -68,10 +68,10 @@ class ActivatePersonalLicenseCommandTest {
 
         command.beforeProcessStarted()
 
-        // when
+        // act
         val result = command.makeProgramCommandLine()
 
-        // then
+        // assert
         result.executablePath shouldBe unityEnvironment.unityPath
         result.workingDirectory shouldBe workingDirectoryPath
         result.environment shouldBe mapOf()
@@ -86,7 +86,7 @@ class ActivatePersonalLicenseCommandTest {
 
     @Test
     fun `should fail when license content is not provided`() {
-        // given
+        // arrange
         val command = createInstance()
         val licenseFilePath = "/path/to/license/file.ulf"
         val logFilePath = "/path/to/logs.txt"
@@ -98,7 +98,7 @@ class ActivatePersonalLicenseCommandTest {
         every { buildFeature.parameters } returns emptyMap()
         command.beforeProcessStarted()
 
-        // when // then
+        // act // assert
         shouldThrow<IllegalStateException> {
             command.makeProgramCommandLine()
         }.apply {
@@ -108,17 +108,17 @@ class ActivatePersonalLicenseCommandTest {
 
     @Test
     fun `should open a log block when process is started`() {
-        // given
+        // arrange
         val commandLine = aCommandLine()
         val command = createInstance()
 
         every { buildLogger.logMessage(any()) } returns Unit
         every { buildLogger.message(any()) } returns Unit
 
-        // when
+        // act
         command.processStarted(commandLine, workingDirectory)
 
-        // then
+        // assert
         verify(exactly = 1) {
             buildLogger.logMessage(withArg {
                 it.value shouldBe BlockData("Activate Unity license", "unity")

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/ActivateProLicenseCommandTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/ActivateProLicenseCommandTest.kt
@@ -53,7 +53,7 @@ class ActivateProLicenseCommandTest {
 
     @Test
     fun `should make program command line`() {
-        // given
+        // arrange
         val command = createInstance()
         val logFile = mockk<Path>()
         val logPath = "/path/to/logs.txt"
@@ -72,10 +72,10 @@ class ActivateProLicenseCommandTest {
 
         command.beforeProcessStarted()
 
-        // when
+        // act
         val result = command.makeProgramCommandLine()
 
-        // then
+        // assert
         result.executablePath shouldBe unityEnvironment.unityPath
         result.workingDirectory shouldBe workingDirectoryPath
         result.environment shouldBe mapOf()
@@ -90,17 +90,17 @@ class ActivateProLicenseCommandTest {
 
     @Test
     fun `should open a log block when process is started`() {
-        // given
+        // arrange
         val commandLine = aCommandLine()
         val command = createInstance()
 
         every { buildLogger.logMessage(any()) } returns Unit
         every { buildLogger.message(any()) } returns Unit
 
-        // when
+        // act
         command.processStarted(commandLine, workingDirectory)
 
-        // then
+        // assert
         verify(exactly = 1) {
             buildLogger.logMessage(withArg {
                 it.value shouldBe BlockData("Activate Unity license", "unity")
@@ -114,14 +114,14 @@ class ActivateProLicenseCommandTest {
 
     @Test
     fun `should close a log block when process is finished`() {
-        // given
+        // arrange
         val command = createInstance()
         every { buildLogger.logMessage(any()) } returns Unit
 
-        // when
+        // act
         command.processFinished(0)
 
-        // then
+        // assert
         verify(exactly = 1) {
             buildLogger.logMessage(withArg {
                 it.value shouldBe BlockData("Activate Unity license", "unity")

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/ReturnProLicenseCommandTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/ReturnProLicenseCommandTest.kt
@@ -53,7 +53,7 @@ class ReturnProLicenseCommandTest {
 
     @Test
     fun `should make program command line`() {
-        // given
+        // arrange
         val command = createInstance()
         val logFile = mockk<Path>()
         val logPath = "/path/to/logs.txt"
@@ -71,10 +71,10 @@ class ReturnProLicenseCommandTest {
 
         command.beforeProcessStarted()
 
-        // when
+        // act
         val result = command.makeProgramCommandLine()
 
-        // then
+        // assert
         result.executablePath shouldBe unityEnvironment.unityPath
         result.workingDirectory shouldBe workingDirectoryPath
         result.environment shouldBe mapOf()
@@ -89,17 +89,17 @@ class ReturnProLicenseCommandTest {
 
     @Test
     fun `should open a log block when process is started`() {
-        // given
+        // arrange
         val commandLine = aCommandLine()
         val command = createInstance()
 
         every { buildLogger.logMessage(any()) } returns Unit
         every { buildLogger.message(any()) } returns Unit
 
-        // when
+        // act
         command.processStarted(commandLine, workingDirectory)
 
-        // then
+        // assert
         verify(exactly = 1) {
             buildLogger.logMessage(withArg {
                 it.value shouldBe BlockData("Return Unity license", "unity")
@@ -113,14 +113,14 @@ class ReturnProLicenseCommandTest {
 
     @Test
     fun `should close a log block when process is finished`() {
-        // given
+        // arrange
         val command = createInstance()
         every { buildLogger.logMessage(any()) } returns Unit
 
-        // when
+        // act
         command.processFinished(0)
 
-        // then
+        // assert
         verify(exactly = 1) {
             buildLogger.logMessage(withArg {
                 it.value shouldBe BlockData("Return Unity license", "unity")

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/UnityLicenseManagerTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/license/UnityLicenseManagerTest.kt
@@ -39,17 +39,17 @@ class UnityLicenseManagerTest {
 
     @Test(dataProvider = "should manage professional license params")
     fun `should activate professional license`(params: Map<String, String>) {
-        // given
+        // arrange
         val manager = createInstance()
         val unityEnvironment = anUnityEnvironment()
 
         every { buildFeature.parameters } returns params
         every { activateProCommand.withUnityEnvironment(unityEnvironment) } returns activateProCommand
 
-        // when
+        // act
         val commands = manager.activateLicense(unityEnvironment, runnerContext).toList()
 
-        // then
+        // assert
         commands.shouldNotBeEmpty()
         commands.shouldContainExactly(activateProCommand)
 
@@ -60,17 +60,17 @@ class UnityLicenseManagerTest {
 
     @Test(dataProvider = "should manage professional license params")
     fun `should return professional license`(params: Map<String, String>) {
-        // given
+        // arrange
         val manager = createInstance()
         val unityEnvironment = anUnityEnvironment()
 
         every { buildFeature.parameters } returns params
         every { returnProCommand.withUnityEnvironment(unityEnvironment) } returns returnProCommand
 
-        // when
+        // act
         val commands = manager.returnLicense(unityEnvironment, runnerContext).toList()
 
-        // then
+        // assert
         commands.shouldNotBeEmpty()
         commands.shouldContainExactly(returnProCommand)
 
@@ -81,17 +81,17 @@ class UnityLicenseManagerTest {
 
     @Test
     fun `should activate personal license`() {
-        // given
+        // arrange
         val manager = createInstance()
         val unityEnvironment = anUnityEnvironment()
 
         every { buildFeature.parameters } returns mapOf("unityLicenseType" to "personalLicense")
         every { activatePersonalCommand.withUnityEnvironment(unityEnvironment) } returns activatePersonalCommand
 
-        // when
+        // act
         val commands = manager.activateLicense(unityEnvironment, runnerContext).toList()
 
-        // then
+        // assert
         commands.shouldNotBeEmpty()
         commands.shouldContainExactly(activatePersonalCommand)
 
@@ -102,16 +102,16 @@ class UnityLicenseManagerTest {
 
     @Test
     fun `should not return personal license`() {
-        // given
+        // arrange
         val manager = createInstance()
         val unityEnvironment = anUnityEnvironment()
 
         every { buildFeature.parameters } returns mapOf("unityLicenseType" to "personalLicense")
 
-        // when
+        // act
         val commands = manager.returnLicense(unityEnvironment, runnerContext).toList()
 
-        // then
+        // assert
         commands.shouldBeEmpty()
 
         verify { activatePersonalCommand wasNot Called }
@@ -130,17 +130,17 @@ class UnityLicenseManagerTest {
 
     @Test(dataProvider = "should not manage licenses params")
     fun `should not manage licenses`(params: Map<String, String>) {
-        // given
+        // arrange
         val manager = createInstance()
         val unityEnvironment = anUnityEnvironment()
 
         every { buildFeature.parameters } returns params
 
-        // when
+        // act
         val activateCommands = manager.activateLicense(unityEnvironment, runnerContext).toList()
         val returnCommands = manager.returnLicense(unityEnvironment, runnerContext).toList()
 
-        // then
+        // assert
         activateCommands.shouldBeEmpty()
         returnCommands.shouldBeEmpty()
 

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/logging/LineStatusProviderTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/logging/LineStatusProviderTest.kt
@@ -25,11 +25,11 @@ class LineStatusProviderTest {
 
     @Test
     fun testCustomFile() {
-        // given
+        // arrange
         val customSettingsFile = File("src/test/resources/logger/customLogging.xml")
         val provider = LineStatusProvider(customSettingsFile)
 
-        // when // then
+        // act // assert
         provider.getLineStatus("text") shouldBeEqual Normal
         provider.getLineStatus("error message") shouldBeEqual Normal
         provider.getLineStatus("warning message") shouldBeEqual Normal

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/util/FileSystemServiceTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/util/FileSystemServiceTest.kt
@@ -12,27 +12,27 @@ class FileSystemServiceTest {
 
     @Test
     fun `should create file`() {
-        // given
+        // arrange
         val service = createInstance()
 
-        // when
-        val result = service.createFile(path)
+        // act
+        val result = service.createPath(path)
 
-        // then
+        // assert
         result shouldBe Path.of(path)
     }
 
     @Test
     fun `should create file in parent directory`() {
-        // given
+        // arrange
         val parentDirectory = Path.of(path)
         val filename = "file.txt"
         val service = createInstance()
 
-        // when
-        val result = service.createFile(parentDirectory, filename)
+        // act
+        val result = service.createPath(parentDirectory, filename)
 
-        // then
+        // assert
         result shouldBe Path.of(parentDirectory.absolutePathString(), filename)
     }
 

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/util/UnityParametersExtractorTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/util/UnityParametersExtractorTest.kt
@@ -29,13 +29,13 @@ class UnityParametersExtractorTest {
 
     @Test
     fun `should return unityRoot from runner parameters`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf("unityRoot" to "/path/to/unity")
 
-        // when
+        // act
         val result = runnerContext.unityRootParam()
 
-        // then
+        // assert
         result shouldNotBe null
         result?.shouldBeEqual("/path/to/unity")
 
@@ -45,40 +45,40 @@ class UnityParametersExtractorTest {
 
     @Test
     fun `should return unityRoot from build feature parameters`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf()
         every { buildFeature.parameters } returns mapOf("unityRoot" to "/path/to/unity")
 
-        // when
+        // act
         val result = runnerContext.unityRootParam()
 
-        // then
+        // assert
         result shouldNotBe null
         result?.shouldBeEqual("/path/to/unity")
     }
 
     @Test
     fun `should return null if unityRoot parameter is not found`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf()
         every { buildFeature.parameters } returns mapOf()
 
-        // when
+        // act
         val result = runnerContext.unityRootParam()
 
-        // then
+        // assert
         result shouldBe null
     }
 
     @Test
     fun `should return unity version from runner parameters`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf("unityVersion" to "2023.1.1")
 
-        // when
+        // act
         val result = runnerContext.unityVersionParam()
 
-        // then
+        // assert
         result shouldNotBe null
         result?.shouldBeEqual(UnityVersion(2023, 1, 1))
 
@@ -88,27 +88,27 @@ class UnityParametersExtractorTest {
 
     @Test
     fun `should return unity version from build feature parameters`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf()
         every { buildFeature.parameters } returns mapOf("unityVersion" to "2023.1.1")
 
-        // when
+        // act
         val result = runnerContext.unityVersionParam()
 
-        // then
+        // assert
         result shouldNotBe null
         result?.shouldBeEqual(UnityVersion(2023, 1, 1))
     }
 
     @Test
     fun `should return unity version when it is surrounded with spaces`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf("unityVersion" to " 2023.1.1 ")
 
-        // when
+        // act
         val result = runnerContext.unityVersionParam()
 
-        // then
+        // assert
         result shouldNotBe null
         result?.shouldBeEqual(UnityVersion(2023, 1, 1))
 
@@ -118,26 +118,26 @@ class UnityParametersExtractorTest {
 
     @Test
     fun `should return null if unityVersion parameter is not found`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf()
         every { buildFeature.parameters } returns mapOf()
 
-        // when
+        // act
         val result = runnerContext.unityVersionParam()
 
-        // then
+        // assert
         result shouldBe null
     }
 
     @Test
     fun `should return null if unityVersion parameter contains not valid version`() {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf("unityVersion" to "invalid version string")
 
-        // when
+        // act
         val result = runnerContext.unityVersionParam()
 
-        // then
+        // assert
         result shouldBe null
     }
 
@@ -155,14 +155,14 @@ class UnityParametersExtractorTest {
         params: Map<String, String>,
         expectedLicenseType: UnityLicenseTypeParameter?,
     ) {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf()
         every { buildFeature.parameters } returns params
 
-        // when
+        // act
         val result = runnerContext.unityLicenseTypeParam()
 
-        // then
+        // assert
         if (expectedLicenseType == null)
             result shouldBe null
         else
@@ -180,14 +180,14 @@ class UnityParametersExtractorTest {
         params: Map<String, String>,
         expectedContent: String?,
     ) {
-        // given
+        // arrange
         every { runnerContext.runnerParameters } returns mapOf()
         every { buildFeature.parameters } returns params
 
-        // when
+        // act
         val result = runnerContext.unityPersonalLicenseContentParam()
 
-        // then
+        // assert
         if (expectedContent == null)
             result shouldBe null
         else

--- a/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
+++ b/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
@@ -35,7 +35,7 @@ object UnityConstants {
     const val PARAM_BUILD_PLAYER = "buildPlayer"
     const val PARAM_BUILD_PLAYER_PATH = "buildPlayerPath"
     const val PARAM_NO_GRAPHICS = "noGraphics"
-    const val PARAM_QUIT = "quit"
+    const val PARAM_NO_QUIT = "noQuit"
     const val PARAM_ARGUMENTS = "arguments"
     const val PARAM_UNITY_VERSION = "unityVersion"
     const val PARAM_UNITY_ROOT = "unityRoot"

--- a/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
+++ b/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
@@ -35,6 +35,7 @@ object UnityConstants {
     const val PARAM_BUILD_PLAYER = "buildPlayer"
     const val PARAM_BUILD_PLAYER_PATH = "buildPlayerPath"
     const val PARAM_NO_GRAPHICS = "noGraphics"
+    const val PARAM_QUIT = "quit"
     const val PARAM_ARGUMENTS = "arguments"
     const val PARAM_UNITY_VERSION = "unityVersion"
     const val PARAM_UNITY_ROOT = "unityRoot"

--- a/plugin-unity-common/src/test/kotlin/jetbrains/buildServer/unity/UnityEnvironmentTest.kt
+++ b/plugin-unity-common/src/test/kotlin/jetbrains/buildServer/unity/UnityEnvironmentTest.kt
@@ -7,10 +7,10 @@ class UnityEnvironmentTest {
 
     @Test
     fun `should create unity environment`() {
-        // when
+        // act
         val environment = UnityEnvironment("/path/to/unity", UnityVersion(2023, 1, 1), true)
 
-        // then
+        // assert
         environment.unityPath shouldBe "/path/to/unity"
         environment.unityVersion shouldBe UnityVersion(2023, 1, 1)
         environment.isVirtual shouldBe true
@@ -18,10 +18,10 @@ class UnityEnvironmentTest {
 
     @Test
     fun `should create non-virtual unity environment by default`() {
-        // when
+        // act
         val environment = UnityEnvironment("/path/to/unity", UnityVersion(2023, 1, 1))
 
-        // then
+        // assert
         environment.unityPath shouldBe "/path/to/unity"
         environment.unityVersion shouldBe UnityVersion(2023, 1, 1)
         environment.isVirtual shouldBe false

--- a/plugin-unity-common/src/test/kotlin/jetbrains/buildServer/unity/UnityVersionTest.kt
+++ b/plugin-unity-common/src/test/kotlin/jetbrains/buildServer/unity/UnityVersionTest.kt
@@ -18,7 +18,7 @@ class UnityVersionTest {
 
     @Test
     fun `should have correct equals and hashcode implementation`() {
-        // given
+        // arrange
         val v1 = UnityVersion(2023, 1, 1)
         val v2 = UnityVersion(2023, 1, 1)
 
@@ -26,7 +26,7 @@ class UnityVersionTest {
         val v4 = UnityVersion(2023, 2, 1)
         val v5 = UnityVersion(2024, 1, 1)
 
-        // then
+        // assert
         v1 shouldBeEqual v2
         v1.hashCode() shouldBeEqual v2.hashCode()
 
@@ -39,12 +39,12 @@ class UnityVersionTest {
 
     @Test
     fun `should have correct toString implementation`() {
-        // given
+        // arrange
         val v1 = UnityVersion(2023, 1, 1)
         val v2 = UnityVersion(2023, 1)
         val v3 = UnityVersion(2023)
 
-        // then
+        // assert
         v1.toString() shouldBeEqual "2023.1.1"
         v2.toString() shouldBeEqual "2023.1"
         v3.toString() shouldBeEqual "2023"
@@ -52,11 +52,11 @@ class UnityVersionTest {
 
     @Test
     fun `should have correct compareTo implementation`() {
-        // given
+        // arrange
         val v1 = UnityVersion(2023, 1, 1)
         val v2 = UnityVersion(2023, 1, 2)
 
-        // then
+        // assert
         v1 shouldBeLessThan v2
         v1 shouldBeLessThanOrEqualTo v1
         v2 shouldBeGreaterThan v1
@@ -76,35 +76,35 @@ class UnityVersionTest {
     // Consider changing this behaviour in case the suffix becomes important
     @Test(dataProvider = "valid version suffixes")
     fun `should ignore version suffix`(versionSuffix: String) {
-        // given
+        // arrange
         val versionWithoutSuffix = UnityVersion(2023, 1, 1)
         val versionWithSuffix = parseVersion(versionWithoutSuffix.toString() + versionSuffix + "ignored part")
 
-        // then
+        // assert
         versionWithoutSuffix shouldBeEqual versionWithSuffix
     }
 
     @Test
     fun `should return next major version`() {
-        // given
+        // arrange
         val version = UnityVersion(2023, 1, 1)
 
-        // when
+        // act
         val nextMajor = version.nextMajor()
 
-        // then
+        // assert
         nextMajor shouldBeEqual UnityVersion(2024, 0, 0)
     }
 
     @Test
     fun `should return next minor version`() {
-        // given
+        // arrange
         val version = UnityVersion(2023, 1, 1)
 
-        // when
+        // act
         val nextMinor = version.nextMinor()
 
-        // then
+        // assert
         nextMinor shouldBeEqual UnityVersion(2023, 2, 0)
     }
 
@@ -126,20 +126,20 @@ class UnityVersionTest {
 
     @Test(dataProvider = "valid unity versions")
     fun `should successfully try to parse valid Unity version`(version: String, expectedVersion: UnityVersion) {
-        // when
+        // act
         val result = tryParseVersion(version)
 
-        // then
+        // assert
         result shouldNotBe null
         result?.shouldBeEqual(expectedVersion)
     }
 
     @Test(dataProvider = "valid unity versions")
     fun `should successfully parse valid Unity version`(version: String, expectedVersion: UnityVersion) {
-        // when
+        // act
         val result = parseVersion(version)
 
-        // then
+        // assert
         result shouldBeEqual expectedVersion
     }
 
@@ -151,13 +151,13 @@ class UnityVersionTest {
 
     @Test(dataProvider = "invalid unity versions")
     fun `should return null when Unity version cannot be parsed`(version: String) {
-        // then
+        // assert
         tryParseVersion(version) shouldBe null
     }
 
     @Test(dataProvider = "invalid unity versions")
     fun `should throw an exception when Unity version cannot be parsed`(version: String) {
-        // then
+        // assert
         shouldThrowExactly<InvalidUnityVersionException> { parseVersion(version) }
     }
 }

--- a/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
+++ b/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
@@ -41,6 +41,9 @@ class UnityParametersProvider {
     val noGraphics: String
         get() = UnityConstants.PARAM_NO_GRAPHICS
 
+    val quit: String
+        get() = UnityConstants.PARAM_QUIT
+
     val arguments: String
         get() = UnityConstants.PARAM_ARGUMENTS
 

--- a/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
+++ b/plugin-unity-server/src/main/kotlin/jetbrains/buildServer/unity/UnityParametersProvider.kt
@@ -41,8 +41,8 @@ class UnityParametersProvider {
     val noGraphics: String
         get() = UnityConstants.PARAM_NO_GRAPHICS
 
-    val quit: String
-        get() = UnityConstants.PARAM_QUIT
+    val noQuit: String
+        get() = UnityConstants.PARAM_NO_QUIT
 
     val arguments: String
         get() = UnityConstants.PARAM_ARGUMENTS

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -153,9 +153,9 @@
         <props:checkboxProperty name="${params.noGraphics}"/>
         <label for="${params.noGraphics}">Do not initialize the graphics device</label><br/>
         <props:checkboxProperty name="${params.silentCrashes}"/>
-        <label for="${params.silentCrashes}">Do not display the error dialog when a standalone player crashes</label>
-        <props:checkboxProperty name="${params.quit}" value="true"/>
-        <label for="${params.quit}">Quit the Unity Editor after other commands have finished executing</label>
+        <label for="${params.silentCrashes}">Do not display the error dialog when a standalone player crashes</label><br/>
+        <props:checkboxProperty name="${params.noQuit}"/>
+        <label for="${params.noQuit}">Do not quit the Unity Editor when execute method is complete</label>
     </td>
 </tr>
 </l:settingsGroup>

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -155,7 +155,7 @@
         <props:checkboxProperty name="${params.silentCrashes}"/>
         <label for="${params.silentCrashes}">Do not display the error dialog when a standalone player crashes</label><br/>
         <props:checkboxProperty name="${params.noQuit}"/>
-        <label for="${params.noQuit}">Do not quit the Unity Editor when execute method is complete</label>
+        <label for="${params.noQuit}">Do not quit the Unity Editor after other commands have finished executing</label>
     </td>
 </tr>
 </l:settingsGroup>

--- a/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/editUnityParameters.jsp
@@ -154,6 +154,8 @@
         <label for="${params.noGraphics}">Do not initialize the graphics device</label><br/>
         <props:checkboxProperty name="${params.silentCrashes}"/>
         <label for="${params.silentCrashes}">Do not display the error dialog when a standalone player crashes</label>
+        <props:checkboxProperty name="${params.quit}" value="true"/>
+        <label for="${params.quit}">Quit the Unity Editor after other commands have finished executing</label>
     </td>
 </tr>
 </l:settingsGroup>

--- a/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
@@ -61,6 +61,12 @@
     </div>
 </c:if>
 
+<c:if test="${propertiesBean.properties[params.quit]}">
+    <div class="parameter">
+        Quit the Unity Editor after other commands have finished executing: <strong>ON</strong>
+    </div>
+</c:if>
+
 <c:if test="${propertiesBean.properties[params.runEditorTests]}">
     <div class="parameter">
         Run Editor tests from the project: <strong>ON</strong>

--- a/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
@@ -61,9 +61,9 @@
     </div>
 </c:if>
 
-<c:if test="${propertiesBean.properties[params.quit]}">
+<c:if test="${propertiesBean.properties[params.noQuit]}">
     <div class="parameter">
-        Quit the Unity Editor after other commands have finished executing: <strong>ON</strong>
+        Do not quit the Unity Editor when execute method is complete: <strong>ON</strong>
     </div>
 </c:if>
 

--- a/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
+++ b/plugin-unity-server/src/main/resources/buildServerResources/viewUnityParameters.jsp
@@ -63,7 +63,7 @@
 
 <c:if test="${propertiesBean.properties[params.noQuit]}">
     <div class="parameter">
-        Do not quit the Unity Editor when execute method is complete: <strong>ON</strong>
+        Do not quit the Unity Editor after other commands have finished executing: <strong>ON</strong>
     </div>
 </c:if>
 


### PR DESCRIPTION
Add checkbox param to disable '-quit' command line option.
Logic is inverted to avoid problems and keep "-quit" by default.

resolve #34 