### PR TITLE
TW-77411 Switch plugin to use the new supplier APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     def correctVersion = project.hasProperty('versionNumber') && property('versionNumber') ==~ /\d+\.\d+\.\d+.*/
     versionNumber = correctVersion ? property('versionNumber') : 'SNAPSHOT-' + new Date().format('yyyyMMddHHmmss')
     projectIds = ['group': 'teamcity-unity-plugin', 'version': versionNumber]
-    teamcityVersion = project.hasProperty('teamcityVersion') ? property('teamcityVersion') : '2018.1'
+    teamcityVersion = project.hasProperty('teamcityVersion') ? property('teamcityVersion') : '2022.10'
 }
 
 group = projectIds.group


### PR DESCRIPTION
The unity plugin is a fit candidate to use the new supplier APIs for parameters

This, however, means, that if an agent is initialized from cache, its own internal state must be initialized from the state.