### PR TITLE
Remove use of Path.of to maintain compatibility with Java 8

### DIFF
--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/util/FileSystemService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/util/FileSystemService.kt
@@ -1,5 +1,6 @@
 package jetbrains.buildServer.unity.util
 
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
@@ -8,9 +9,9 @@ import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 class FileSystemService {
-    fun createPath(path: String): Path = Path.of(path)
+    fun createPath(path: String): Path = File(path).toPath()
 
-    fun createPath(parent: Path, child: String): Path = Path.of(parent.absolutePathString(), child)
+    fun createPath(parent: Path, child: String): Path = File(parent.absolutePathString(), child).toPath()
 
     fun createTempFile(directory: Path, prefix: String, suffix: String): Path {
         return Files.createTempFile(directory, prefix, suffix)

--- a/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/util/FileSystemServiceTest.kt
+++ b/plugin-unity-agent/src/test/kotlin/jetbrains/buildServer/unity/util/FileSystemServiceTest.kt
@@ -2,13 +2,13 @@ package jetbrains.buildServer.unity.util
 
 import io.kotest.matchers.shouldBe
 import org.testng.annotations.Test
-import java.io.File.pathSeparator
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
 class FileSystemServiceTest {
 
-    private val path = "some" + pathSeparator + "path"
+    private val path = "some" + File.pathSeparator + "path"
 
     @Test
     fun `should create file`() {
@@ -19,7 +19,7 @@ class FileSystemServiceTest {
         val result = service.createPath(path)
 
         // assert
-        result shouldBe Path.of(path)
+        result shouldBe File(path).toPath()
     }
 
     @Test
@@ -33,7 +33,7 @@ class FileSystemServiceTest {
         val result = service.createPath(parentDirectory, filename)
 
         // assert
-        result shouldBe Path.of(parentDirectory.absolutePathString(), filename)
+        result shouldBe File(parentDirectory.absolutePathString(), filename).toPath()
     }
 
     private fun createInstance() = FileSystemService()


### PR DESCRIPTION
I'm not a java developer so apologies if I'm understanding wrong, but e27f4cc broke compatibility with Java 8 due to using `Path.of` which isn't available in that version. This change fixes that by reverting to use of `File` and `toPath`