### PR TITLE
Use new Accelerator Cache Server

### DIFF
--- a/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
+++ b/plugin-unity-agent/src/main/kotlin/jetbrains/buildServer/unity/UnityRunnerBuildService.kt
@@ -186,7 +186,7 @@ class UnityRunnerBuildService(
         build.getBuildFeaturesOfType(BUILD_FEATURE_TYPE).firstOrNull()?.let { feature ->
             feature.parameters[PARAM_CACHE_SERVER]?.let {
                 if (it.isNotEmpty()) {
-                    arguments.addAll(listOf(ARG_CACHE_SERVER_IP_ADDRESS, it.trim()))
+                    arguments.addAll(listOf(ARG_ENABLE_CACHE_SERVER, ARG_CACHE_SERVER_ENDPOINT, it.trim()))
                 }
             }
         }
@@ -367,7 +367,8 @@ class UnityRunnerBuildService(
         private const val ARG_CLEANED_LOG_FILE = "-cleanedLogFile"
         private const val ARG_NO_GRAPHICS = "-nographics"
         private const val ARG_QUIT = "-quit"
-        private const val ARG_CACHE_SERVER_IP_ADDRESS = "-CacheServerIPAddress"
+        private const val ARG_ENABLE_CACHE_SERVER = "-EnableCacheServer"
+        private const val ARG_CACHE_SERVER_ENDPOINT = "-cacheServerEndpoint"
 
         private const val LOG_FILE_ACCESS_MODE = "rw"
 


### PR DESCRIPTION
Currently there's no way to use the new accelerator cache server for Unity (available since 2019.3) as the command line arguments are different.

Old: `-CacheServerIPAddress`
New: `-EnableCacheServer` and `-cacheServerEndpoint`.

This change updates the command line arguments to use the new one.

Obviously this has an impact on unity version compatibility, but I'm not completely sure how to handle that in the code, and I'm not convinced it's correct currently anyway as the readme states version 2017+ but even the old/current argument was only made available in 2018 as far as I can tell, so I think the three options are:

- Change version compatibility of this plugin to support only unity 2019.3+
- Keep things as they are, Presuming the argument is just ignored on older versions currently?
- Update code to add options to choose new/old cache server and also only make the option(s) available on versions that support them
